### PR TITLE
Expand integer range

### DIFF
--- a/ngrep.c
+++ b/ngrep.c
@@ -75,6 +75,7 @@
 #include <signal.h>
 #include <locale.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #if !defined(_WIN32)
 #include <errno.h>
@@ -179,7 +180,7 @@ SOCKET delay_socket = 0;
 void (*print_time)() = NULL, (*dump_delay)() = dump_delay_proc_init;
 
 uint64_t parse_uint64(const char *s);
-void dierange(char *msg, unsigned long value);
+void dierange(char *msg, uint64_t value);
 
 /*
  * Window-size functionality (adjust output based on width of console display)
@@ -1600,7 +1601,8 @@ uint64_t parse_uint64(const char *s) {
     return n;
 }
 
-void dierange(char *msg, unsigned long value) {
-    fprintf(stderr, "`%s': value `%lu' is out of range.\n", msg, value);
+void dierange(char *msg, uint64_t value) {
+    fprintf(stderr, "`%s': value `%" PRIu64 "' is out of range.\n",
+            msg, value);
     clean_exit(-1);
 }

--- a/ngrep.c
+++ b/ngrep.c
@@ -350,6 +350,12 @@ int main(int argc, char **argv) {
 #if USE_TCPKILL
             case 'K':
                 tcpkill_active = parseulong(optarg);
+                /* Parameter kill_count of tcpkill_kill has type
+                   unsigned: check that tcpkill_active is not beyond
+                   range. */
+                if (tcpkill_active > UINT_MAX) {
+                    dierange("-K", tcpkill_active);
+                }
                 break;
 #endif
             case 'h':

--- a/ngrep.c
+++ b/ngrep.c
@@ -234,9 +234,15 @@ int main(int argc, char **argv) {
             case 'P':
                 nonprint_char = *optarg;
                 break;
-            case 'S':
-                limitlen = atoi(optarg);
+            case 'S': {
+                unsigned long limitlenul = parseulong(optarg);
+                if (limitlenul > UINT16_MAX) {
+                    dierange("-S", limitlenul);
+                }
+
+                limitlen = limitlenul;
                 break;
+            }
             case 'O':
                 dump_file = optarg;
                 break;

--- a/ngrep.c
+++ b/ngrep.c
@@ -176,6 +176,8 @@ SOCKET delay_socket = 0;
 
 void (*print_time)() = NULL, (*dump_delay)() = dump_delay_proc_init;
 
+unsigned long parseulong(const char *s);
+void dierange(char *msg, unsigned long value);
 
 /*
  * Window-size functionality (adjust output based on width of console display)
@@ -1557,4 +1559,27 @@ char *win32_choosedevice(void) {
 }
 #endif
 
+/* Parse an unsigned long, exit program if anything goes wrong. */
+unsigned long parseulong(const char *s) {
+    unsigned long n = 0;
+    char *end = NULL;
 
+    errno = 0;
+    n = strtoul(s, &end, 0);
+
+    if (errno != 0 || *s == '\0' || end == NULL || *end != '\0') {
+        if (errno != 0) { /* GNU strtoul will set errno. */
+            perror("strtoul");
+        }
+        fprintf(stderr, "Could not convert unsigned long: `%s'.\n", s);
+
+        clean_exit(-1);
+    }
+
+    return n;
+}
+
+void dierange(char *msg, unsigned long value) {
+    fprintf(stderr, "`%s': value `%lu' is out of range.\n", msg, value);
+    clean_exit(-1);
+}

--- a/ngrep.c
+++ b/ngrep.c
@@ -105,9 +105,10 @@
  */
 
 uint16_t snaplen = 65535, limitlen = 65535, promisc = 1, to = 100;
-uint16_t match_after = 0, keep_matching = 0, matches = 0, max_matches = 0;
+unsigned long match_after = 0, keep_matching = 0, matches = 0, max_matches = 0;
+
 #if USE_TCPKILL
-uint16_t tcpkill_active = 0;
+unsigned long tcpkill_active = 0;
 #endif
 
 uint8_t  re_match_word = 0, re_ignore_case = 0, re_multiline_match = 1;
@@ -183,7 +184,7 @@ void dierange(char *msg, unsigned long value);
  * Window-size functionality (adjust output based on width of console display)
  */
 
-uint32_t ws_row, ws_col = 80, ws_col_forced = 0;
+unsigned long ws_row, ws_col = 80, ws_col_forced = 0;
 
 
 int main(int argc, char **argv) {
@@ -250,7 +251,7 @@ int main(int argc, char **argv) {
                 read_file = optarg;
                 break;
             case 'A':
-                match_after = atoi(optarg) + 1;
+                match_after = parseulong(optarg) + 1; /* FIXME: range check */
                 break;
 #if defined(_WIN32)
             case 'L':
@@ -268,15 +269,17 @@ int main(int argc, char **argv) {
                 break;
 #endif
             case 'c':
-                ws_col_forced = atoi(optarg);
+                ws_col_forced = parseulong(optarg);
                 break;
             case 'n':
-                max_matches = atoi(optarg);
+                max_matches = parseulong(optarg);
                 break;
             case 's': {
-                uint16_t value = atoi(optarg);
-                if (value > 0)
-                    snaplen = value;
+                unsigned long value = parseulong(optarg);
+                if (value > UINT16_MAX) {
+                    dierange("-s", value);
+                }
+                snaplen = value;
             } break;
             case 'C':
                 enable_hilite = 1;
@@ -341,7 +344,7 @@ int main(int argc, char **argv) {
                 break;
 #if USE_TCPKILL
             case 'K':
-                tcpkill_active = atoi(optarg);
+                tcpkill_active = parseulong(optarg);
                 break;
 #endif
             case 'h':

--- a/ngrep.c
+++ b/ngrep.c
@@ -106,7 +106,7 @@
  */
 
 uint16_t snaplen = 65535, limitlen = 65535, promisc = 1, to = 100;
-unsigned long match_after = 0, keep_matching = 0, matches = 0, max_matches = 0;
+uint64_t match_after = 0, keep_matching = 0, matches = 0, max_matches = 0;
 
 #if USE_TCPKILL
 unsigned long tcpkill_active = 0;
@@ -178,14 +178,14 @@ SOCKET delay_socket = 0;
 
 void (*print_time)() = NULL, (*dump_delay)() = dump_delay_proc_init;
 
-unsigned long parseulong(const char *s);
+uint64_t parse_uint64(const char *s);
 void dierange(char *msg, unsigned long value);
 
 /*
  * Window-size functionality (adjust output based on width of console display)
  */
 
-unsigned long ws_row, ws_col = 80, ws_col_forced = 0;
+uint64_t ws_row, ws_col = 80, ws_col_forced = 0;
 
 
 int main(int argc, char **argv) {
@@ -237,7 +237,7 @@ int main(int argc, char **argv) {
                 nonprint_char = *optarg;
                 break;
             case 'S': {
-                unsigned long limitlenul = parseulong(optarg);
+                uint64_t limitlenul = parse_uint64(optarg);
                 if (limitlenul > UINT16_MAX) {
                     dierange("-S", limitlenul);
                 }
@@ -252,7 +252,7 @@ int main(int argc, char **argv) {
                 read_file = optarg;
                 break;
             case 'A':
-                match_after = parseulong(optarg);
+                match_after = parse_uint64(optarg);
                 if (match_after == ULONG_MAX) {
                     dierange("-A", match_after);
                 }
@@ -274,13 +274,13 @@ int main(int argc, char **argv) {
                 break;
 #endif
             case 'c':
-                ws_col_forced = parseulong(optarg);
+                ws_col_forced = parse_uint64(optarg);
                 break;
             case 'n':
-                max_matches = parseulong(optarg);
+                max_matches = parse_uint64(optarg);
                 break;
             case 's': {
-                unsigned long value = parseulong(optarg);
+                uint64_t value = parse_uint64(optarg);
                 if (value > UINT16_MAX) {
                     dierange("-s", value);
                 }
@@ -349,7 +349,7 @@ int main(int argc, char **argv) {
                 break;
 #if USE_TCPKILL
             case 'K':
-                tcpkill_active = parseulong(optarg);
+                tcpkill_active = parse_uint64(optarg);
                 /* Parameter kill_count of tcpkill_kill has type
                    unsigned: check that tcpkill_active is not beyond
                    range. */
@@ -1580,18 +1580,19 @@ char *win32_choosedevice(void) {
 #endif
 
 /* Parse an unsigned long, exit program if anything goes wrong. */
-unsigned long parseulong(const char *s) {
-    unsigned long n = 0;
+uint64_t parse_uint64(const char *s) {
+    unsigned long long n = 0;
     char *end = NULL;
 
     errno = 0;
-    n = strtoul(s, &end, 0);
+    n = strtoull(s, &end, 0);
 
-    if (errno != 0 || *s == '\0' || end == NULL || *end != '\0') {
-        if (errno != 0) { /* GNU strtoul will set errno. */
-            perror("strtoul");
+    if (errno != 0 || *s == '\0' || end == NULL || *end != '\0'
+        || n > UINT64_MAX) {
+        if (errno != 0) { /* GNU strtoull will set errno. */
+            perror("strtoull");
         }
-        fprintf(stderr, "Could not convert unsigned long: `%s'.\n", s);
+        fprintf(stderr, "Could not convert uint64_t: `%s'.\n", s);
 
         clean_exit(-1);
     }

--- a/ngrep.c
+++ b/ngrep.c
@@ -74,6 +74,7 @@
 #include <string.h>
 #include <signal.h>
 #include <locale.h>
+#include <limits.h>
 
 #if !defined(_WIN32)
 #include <errno.h>
@@ -251,7 +252,11 @@ int main(int argc, char **argv) {
                 read_file = optarg;
                 break;
             case 'A':
-                match_after = parseulong(optarg) + 1; /* FIXME: range check */
+                match_after = parseulong(optarg);
+                if (match_after == ULONG_MAX) {
+                    dierange("-A", match_after);
+                }
+                ++match_after;
                 break;
 #if defined(_WIN32)
             case 'L':


### PR DESCRIPTION
The published version of ngrep appears to have to small issues:

* The range for many integral options is small because the underlying type is a 16-bit unsigned (so it's impossible to ask to capture 100000 packets using `-n`, for example);

* the option-parsing code does not check for overflow conditions, resulting in silent wraparound (so that asking to capture exactly 128K packets will be the same as `-n 0`: no limit to how many packets will be captured).

This change set:

* switches the type for many counters to unsigned long, so that it's at least 32 bits;
* checks command line values for syntactic correctness and range, and errors out if needed.