### PR TITLE
Fix two configure issues

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -146,7 +146,7 @@ AC_ARG_ENABLE(pcre,
 [ use_pcre="$enableval" ],
 [ use_pcre="no" ])
 
-if test use_pcre = yes; then
+if test $use_pcre = yes; then
   USE_PCRE="1"
   EXTRA_LIBS="$EXTRA_LIBS -lpcre"
 else

--- a/configure.in
+++ b/configure.in
@@ -174,7 +174,7 @@ dnl
 AC_ARG_ENABLE(tcpkill,
 [  --enable-tcpkill        enable connection killing support (default off)],
 [
-  AC_CHECK_LIB(net, libnet_init_packet,,echo !!! error: tcpkill feature enabled but no libnet found; exit)
+  AC_CHECK_LIB(net, libnet_init,,echo !!! error: tcpkill feature enabled but no libnet found; exit)
   use_tcpkill="$enableval"
 ],
 [ use_tcpkill="no" ])


### PR DESCRIPTION
Fix two configure issues found when updating the Debian package to 1.47:

* A missing $ when testing for $use_pcre, which prevents from configuring ngrep with the system pcre
* The libnet configure stanza checks for libnet_init_packet, which is an old libnet 1.0 function that is long deprecated; use libnet_init instead

I will let you refresh configure after applying these.
Thanks for picking up the other Debian patches in 1.46 and 1.47!