### PR TITLE
fix --disable-tcpkill

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -173,13 +173,11 @@ dnl
 
 AC_ARG_ENABLE(tcpkill,
 [  --enable-tcpkill        enable connection killing support (default off)],
-[
-  AC_CHECK_LIB(net, libnet_init,,echo !!! error: tcpkill feature enabled but no libnet found; exit)
-  use_tcpkill="$enableval"
-],
+[ use_tcpkill="$enableval" ],
 [ use_tcpkill="no" ])
 
 if test $use_tcpkill = yes; then
+  AC_CHECK_LIB(net, libnet_init,,echo !!! error: tcpkill feature enabled but no libnet found; exit)
   USE_TCPKILL="1"
   EXTRA_OBJS="$EXTRA_OBJS tcpkill.o"
   EXTRA_DEFINES="$EXTRA_DEFINES $(libnet-config --defines)"


### PR DESCRIPTION
If the user uses --disable-tcpkill, build can fail if libnet is not
found on the system.

To fix this, move AC_CHECK_LIB to found libnet outside AC_ARG_ENABLE

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>