### PR TITLE
Include <err.h> and "tcpkill.h" to avoid implicit function declarations

### DIFF
--- a/ngrep.c
+++ b/ngrep.c
@@ -98,6 +98,7 @@
 #endif
 
 #include "ngrep.h"
+#include "tcpkill.h"
 
 
 /*

--- a/tcpkill.c
+++ b/tcpkill.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <err.h>
 #include <libnet.h>
 #include <pcap.h>
 


### PR DESCRIPTION
Implicit function declarations are a historic language feature that were removed from C in 1999.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC