### PR TITLE
Fix detection of DLT_* macros

### DIFF
--- a/configure
+++ b/configure
@@ -3890,21 +3890,16 @@ fi
 fi
 
 
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for BPF include path" >&5
-$as_echo_n "checking for BPF include path... " >&6; }
-BPF=`/usr/bin/perl -ne '/include\s+<(.*bpf\.h)>/ && print "$1\n"' $pcap_base/pcap.h`
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $BPF" >&5
-$as_echo "$BPF" >&6; }
+PCAP_H=$pcap_base/pcap.h
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_LINUX_SLL in $BPF" >&5
-$as_echo_n "checking for DLT_LINUX_SLL in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_LINUX_SLL in $PCAP_H" >&5
+$as_echo_n "checking for DLT_LINUX_SLL in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_LINUX_SLL
 yes
 #endif
@@ -3922,12 +3917,12 @@ rm -f conftest*
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_LOOP in $BPF" >&5
-$as_echo_n "checking for DLT_LOOP in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_LOOP in $PCAP_H" >&5
+$as_echo_n "checking for DLT_LOOP in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_LOOP
 yes
 #endif
@@ -3945,12 +3940,12 @@ rm -f conftest*
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_IEEE802_11 in $BPF" >&5
-$as_echo_n "checking for DLT_IEEE802_11 in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_IEEE802_11 in $PCAP_H" >&5
+$as_echo_n "checking for DLT_IEEE802_11 in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_IEEE802_11
 yes
 #endif
@@ -3969,12 +3964,12 @@ rm -f conftest*
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_IEEE802_11_RADIO in $BPF" >&5
-$as_echo_n "checking for DLT_IEEE802_11_RADIO in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_IEEE802_11_RADIO in $PCAP_H" >&5
+$as_echo_n "checking for DLT_IEEE802_11_RADIO in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_IEEE802_11_RADIO
 yes
 #endif
@@ -3993,12 +3988,12 @@ rm -f conftest*
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_RAW in $BPF" >&5
-$as_echo_n "checking for DLT_RAW in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_RAW in $PCAP_H" >&5
+$as_echo_n "checking for DLT_RAW in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_RAW
 yes
 #endif
@@ -4017,12 +4012,12 @@ rm -f conftest*
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_PFLOG in $BPF" >&5
-$as_echo_n "checking for DLT_PFLOG in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_PFLOG in $PCAP_H" >&5
+$as_echo_n "checking for DLT_PFLOG in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_PFLOG
 yes
 #endif
@@ -4041,12 +4036,12 @@ rm -f conftest*
 
 
 present=""
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_IPNET in $BPF" >&5
-$as_echo_n "checking for DLT_IPNET in $BPF... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for DLT_IPNET in $PCAP_H" >&5
+$as_echo_n "checking for DLT_IPNET in $PCAP_H... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_IPNET
 yes
 #endif

--- a/configure.in
+++ b/configure.in
@@ -373,13 +373,7 @@ if test "$USE_PCAP_RESTART" = "1"; then
 fi
 
 
-dnl
-dnl Next figure out which bpf header file to look at.
-dnl
-
-AC_MSG_CHECKING(for BPF include path)
-BPF=`/usr/bin/perl -ne '/include\s+<(.*bpf\.h)>/ && print "$1\n"' $pcap_base/pcap.h`
-AC_MSG_RESULT($BPF)
+PCAP_H=$pcap_base/pcap.h
 
 dnl
 dnl Check for DLT_* types that might not have existed in older
@@ -387,10 +381,10 @@ dnl libpcap's
 dnl
 
 present=""
-AC_MSG_CHECKING(for DLT_LINUX_SLL in $BPF)
+AC_MSG_CHECKING(for DLT_LINUX_SLL in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_LINUX_SLL
 yes
 #endif
@@ -398,10 +392,10 @@ yes
 [HAVE_DLT_LINUX_SLL="1" && AC_MSG_RESULT(yes)], [HAVE_DLT_LINUX_SLL="0" && AC_MSG_RESULT(no)])
 
 present=""
-AC_MSG_CHECKING(for DLT_LOOP in $BPF)
+AC_MSG_CHECKING(for DLT_LOOP in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_LOOP
 yes
 #endif
@@ -409,10 +403,10 @@ yes
 [HAVE_DLT_LOOP="1" && AC_MSG_RESULT(yes)], [HAVE_DLT_LOOP="0" && AC_MSG_RESULT(no)])
 
 present=""
-AC_MSG_CHECKING(for DLT_IEEE802_11 in $BPF)
+AC_MSG_CHECKING(for DLT_IEEE802_11 in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_IEEE802_11
 yes
 #endif
@@ -421,10 +415,10 @@ yes
 
 
 present=""
-AC_MSG_CHECKING(for DLT_IEEE802_11_RADIO in $BPF)
+AC_MSG_CHECKING(for DLT_IEEE802_11_RADIO in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_IEEE802_11_RADIO
 yes
 #endif
@@ -433,10 +427,10 @@ yes
 
 
 present=""
-AC_MSG_CHECKING(for DLT_RAW in $BPF)
+AC_MSG_CHECKING(for DLT_RAW in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_RAW
 yes
 #endif
@@ -445,10 +439,10 @@ yes
 
 
 present=""
-AC_MSG_CHECKING(for DLT_PFLOG in $BPF)
+AC_MSG_CHECKING(for DLT_PFLOG in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_PFLOG
 yes
 #endif
@@ -457,10 +451,10 @@ yes
 
 
 present=""
-AC_MSG_CHECKING(for DLT_IPNET in $BPF)
+AC_MSG_CHECKING(for DLT_IPNET in $PCAP_H)
 AC_EGREP_CPP(yes,
 [
-#include <$BPF>
+#include <$PCAP_H>
 #ifdef DLT_IPNET
 yes
 #endif


### PR DESCRIPTION
`pcap.h` in its entirety must be included in order for `bpf.h` to work properly.

<details><summary>Example test program, compiler output:</summary>

```c
#include <stdio.h>
#include <pcap/bpf.h>

int main(void) {
#ifdef DLT_IEEE802_11
    printf("Yes\n");
#endif
}
```

Output:

```
In file included from t.c:2:
/usr/include/pcap/bpf.h:97:9: error: unknown type name 'u_int'
   97 | typedef u_int bpf_u_int32;
      |         ^~~~~
/usr/include/pcap/bpf.h:117:9: error: unknown type name 'u_int'
  117 |         u_int bf_len;
      |         ^~~~~
/usr/include/pcap/bpf.h:245:9: error: unknown type name 'u_short'
  245 |         u_short code;
      |         ^~~~~~~
/usr/include/pcap/bpf.h:246:9: error: unknown type name 'u_char'
  246 |         u_char  jt;
      |         ^~~~~~
/usr/include/pcap/bpf.h:247:9: error: unknown type name 'u_char'
  247 |         u_char  jf;
      |         ^~~~~~
/usr/include/pcap/bpf.h:271:10: error: unknown type name 'u_int'
  271 | PCAP_API u_int  bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
      |          ^~~~~
/usr/include/pcap/bpf.h:271:59: error: unknown type name 'u_char'
  271 | PCAP_API u_int  bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
      |                                                           ^~~~~~
/usr/include/pcap/bpf.h:271:69: error: unknown type name 'u_int'; did you mean 'int'?
  271 | PCAP_API u_int  bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
      |                                                                     ^~~~~
      |                                                                     int
/usr/include/pcap/bpf.h:271:76: error: unknown type name 'u_int'; did you mean 'int'?
  271 | PCAP_API u_int  bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
      |                                                                            ^~~~~
      |                                                                            int
```

</details>

Changing the example program to include only `pcap.h` works.

Linux x86_64
libpcap 1.10.4
gcc 13.1.0