### PR TITLE
most likely a typo in the redirection (2>&1 and not 2&>1)

### DIFF
--- a/scripts/multi.pl
+++ b/scripts/multi.pl
@@ -73,7 +73,7 @@ sub go {
         sigprocmask(SIG_UNBLOCK, $old_sig_set);
 
 	system("zcat $rule{'file'} | " .
-               "ngrep -qtI - $rule{'regex'} $rule{'filter'} 2&>1 > " .
+               "ngrep -qtI - $rule{'regex'} $rule{'filter'} 2>&1 > " .
                "ngrepped.$rule_name");
 
 	exit;


### PR DESCRIPTION
This candidate was found using Debian Code Search using [12]?&>[12].